### PR TITLE
Replace inline padding with Tailwind

### DIFF
--- a/src/components/CTA.tsx
+++ b/src/components/CTA.tsx
@@ -15,23 +15,17 @@ const CTA = () => {
             </p>
           </div>
           <div className="flex flex-col sm:flex-row gap-4">
-            <a 
-              href="#get-started" 
-              className="bg-white text-black hover:bg-gray-200 flex items-center justify-center group text-center rounded-md transition-colors" 
-              style={{
-                padding: '12px 24px',
-              }}
+            <a
+              href="#get-started"
+              className="bg-white text-black hover:bg-gray-200 flex items-center justify-center group text-center rounded-md transition-colors py-3 px-6"
             >
               Let's Pebble
               <ArrowRight className="ml-2 w-4 h-4 transition-transform group-hover:translate-x-1" />
             </a>
             
-            <a 
-              href="#docs" 
-              className="bg-transparent text-white flex items-center justify-center group text-center border border-gray-300 rounded-md hover:bg-gray-800 transition-all" 
-              style={{
-                padding: '12px 24px',
-              }}
+            <a
+              href="#docs"
+              className="bg-transparent text-white flex items-center justify-center group text-center border border-gray-300 rounded-md hover:bg-gray-800 transition-all py-3 px-6"
             >
               Docs
               <svg className="ml-2 w-4 h-4" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">

--- a/src/components/CTASection.tsx
+++ b/src/components/CTASection.tsx
@@ -17,23 +17,17 @@ const CTASection = () => {
               </p>
             </div>
             <div className="flex flex-col sm:flex-row gap-4">
-              <a 
-                href="/hibiscus" 
-                className="bg-white text-black hover:bg-gray-200 flex items-center justify-center group text-center rounded-md transition-colors" 
-                style={{
-                  padding: '12px 24px',
-                }}
+              <a
+                href="/hibiscus"
+                className="bg-white text-black hover:bg-gray-200 flex items-center justify-center group text-center rounded-md transition-colors py-3 px-6"
               >
                 Let's explore hibiscus
                 <ArrowRight className="ml-2 w-4 h-4 transition-transform group-hover:translate-x-1" />
               </a>
               
-              <a 
-                href="#docs" 
-                className="bg-transparent text-white flex items-center justify-center group text-center border border-gray-300 rounded-md hover:bg-gray-800 transition-all" 
-                style={{
-                  padding: '12px 24px',
-                }}
+              <a
+                href="#docs"
+                className="bg-transparent text-white flex items-center justify-center group text-center border border-gray-300 rounded-md hover:bg-gray-800 transition-all py-3 px-6"
               >
                 Docs
                 <svg className="ml-2 w-4 h-4" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -84,19 +84,9 @@ const Hero = () => {
             className="flex flex-col sm:flex-row gap-4 justify-center opacity-0 animate-fade-in" 
             style={{ animationDelay: "0.7s" }}
           >
-            <a 
-              href="#get-access" 
-              className="bg-gradient-to-r from-gray-700 to-zinc-900 flex items-center justify-center group w-full sm:w-auto text-center" 
-              style={{
-                borderRadius: '1440px',
-                boxSizing: 'border-box',
-                color: '#FFFFFF',
-                cursor: 'pointer',
-                fontSize: '14px',
-                lineHeight: '20px',
-                padding: '16px 24px',
-                border: '1px solid white',
-              }}
+            <a
+              href="#get-access"
+              className="bg-gradient-to-r from-gray-700 to-zinc-900 flex items-center justify-center group w-full sm:w-auto text-center rounded-full text-white cursor-pointer text-sm leading-5 py-4 px-6 border border-white"
             >
               Launch Article
               <ArrowRight className="ml-2 w-4 h-4 transition-transform group-hover:translate-x-1" />

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -145,18 +145,8 @@ const Navbar = () => {
             <UserButton afterSignOutUrl="/" />
           </SignedIn>
           <SignedOut>
-            <Button 
-              className="bg-gradient-to-r from-gray-700 to-zinc-900 flex items-center justify-center group w-full sm:w-auto text-center" 
-              style={{
-                borderRadius: '1440px',
-                boxSizing: 'border-box',
-                color: '#FFFFFF',
-                cursor: 'pointer',
-                fontSize: '14px',
-                lineHeight: '20px',
-                padding: '16px 24px',
-                border: '1px solid white',
-              }}
+            <Button
+              className="bg-gradient-to-r from-gray-700 to-zinc-900 flex items-center justify-center group w-full sm:w-auto text-center rounded-full text-white cursor-pointer text-sm leading-5 py-4 px-6 border border-white"
               onClick={() => redirectToSignIn()}
             >
               Join Us
@@ -211,13 +201,8 @@ const Navbar = () => {
             <UserButton afterSignOutUrl="/" />
           </SignedIn>
           <SignedOut>
-            <Button 
-              className="bg-gradient-to-r from-gray-700 to-zinc-900 text-white rounded-full w-full mt-4"
-              style={{
-                padding: '16px 24px',
-                fontSize: '14px',
-                lineHeight: '20px',
-              }}
+            <Button
+              className="bg-gradient-to-r from-gray-700 to-zinc-900 text-white rounded-full w-full mt-4 text-sm leading-5 py-4 px-6"
               onClick={() => {
                 handleMobileMenuItemClick();
                 redirectToSignIn();


### PR DESCRIPTION
## Summary
- remove inline padding in CTA components and use Tailwind utilities
- apply Tailwind utilities in Hero buttons
- replace inline styles in Navbar buttons with utilities

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*